### PR TITLE
[ci] Upload only missing host packages

### DIFF
--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -41,10 +41,10 @@ jobs:
           conan --version
           conan config home
 
-      - name: Connect to remote
-        run: |
-          conan remote add -i 0 sogo https://sogo.jfrog.io/artifactory/api/conan/conan-center
-          conan user -r sogo -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+      #- name: Connect to remote
+      #  run: |
+      #    conan remote add -i 0 sogo https://sogo.jfrog.io/artifactory/api/conan/conan-center
+      #    conan user -r sogo -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
 
       - name: Copy settings to cache
         run: |
@@ -68,17 +68,20 @@ jobs:
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "conan test \"$d/$folder/test_package/conanfile.py\" $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "****************************************"
-                conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
-                conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
+                conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=$d.json
+                cat $d.json
+                echo conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
+                echo conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
               done
             done
             cd ..
           done
 
-      - name: Upload to remote
-        if: github.ref == 'refs/heads/master'
-        run: |
-          conan upload --confirm --parallel --all --remote sogo "*"
+      #- name: Upload to remote
+      #  # Upload only the packages that were built (they should be only ones in _host_ context)
+      #  if: github.ref == 'refs/heads/master'
+      #  run: |
+      #    conan upload --confirm --parallel --all --remote sogo "*"
 
       - name: Clean cache
         run: |

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -49,10 +49,10 @@ jobs:
           conan --version
           conan config home
 
-      #- name: Connect to remote
-      #  run: |
-      #    conan remote add -i 0 sogo https://sogo.jfrog.io/artifactory/api/conan/conan-center
-      #    conan user -r sogo -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
+      - name: Connect to remote
+        run: |
+          conan remote add -i 0 sogo https://sogo.jfrog.io/artifactory/api/conan/conan-center
+          conan user -r sogo -p ${{secrets.RT_TOKEN}} ${{secrets.RT_USERNAME}}
 
       - name: Copy settings to cache
         run: |
@@ -73,41 +73,33 @@ jobs:
             for d in * ; do
               python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
                 echo "****************************************"
-                echo "folder: $folder, version: $version"
+                echo "folder: $folder, name: $d, version: $version"
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "conan test \"$d/$folder/test_package/conanfile.py\" $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "****************************************"
                 conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=../$d-$version.json
-                cat ../$d-$version.json
-                echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
-                echo "conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
+                conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
+                conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
               done
             done
             cd ..
           done
 
       - name: Upload only packages built
+        # Upload only the packages that were built (they should be only ones in _host_ context)
+        if: github.ref == 'refs/heads/master'
         run: |
           cd recipes
           for d in * ; do
             python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
-              echo "****************************************"
-              echo ""
-              echo "****************************************" 
               jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' ../$d-$version.json | while read -r reference ; do
                 ref_unquoted=$(echo $reference | sed 's/\"//g')
                 ref_usable=$(echo $ref_unquoted | sed '/@/!s/.*/&@/g')
-                echo $ref_usable
+                conan upload --confirm --parallel --all --remote sogo $ref_usable
               done
             done
           done
           
-      #- name: Upload to remote
-      #  # Upload only the packages that were built (they should be only ones in _host_ context)
-      #  if: github.ref == 'refs/heads/master'
-      #  run: |
-      #    conan upload --confirm --parallel --all --remote sogo "*"
-
       - name: Clean cache
         run: |
           conan remove "*" --builds --force

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -65,13 +65,14 @@ jobs:
             for d in * ; do
               python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
                 echo "****************************************"
+                echo "folder: $folder, version: $version"
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "conan test \"$d/$folder/test_package/conanfile.py\" $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "****************************************"
                 conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=$d-$version.json
                 cat $d-$version.json
-                echo conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
-                echo conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
+                echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
+                echo "conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
               done
             done
             cd ..

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -96,7 +96,7 @@ jobs:
               echo "****************************************" 
               jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' ../$d-$version.json | while read -r reference ; do
                 ref_unquoted=$(echo $reference | sed 's/\"//g')
-                ref_usable=$(echo $ref_unquoted | sed 's/.*@.*/&@/')
+                ref_usable=$(echo $ref_unquoted | sed '/@/!s/.*/&@/g')
                 echo $ref_usable
               done
             done

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -81,14 +81,16 @@ jobs:
       - name: Upload only packages built
         run: |
           cd recipes
-          python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
-            echo "****************************************"
-            echo ""
-            echo "****************************************" 
-            jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' ../$d-$version.json | while read -r reference ; do
-              ref_unquoted=$(echo $reference | sed 's/\"//g')
-              ref_usable=$(echo $ref_unquoted | sed 's/.*@.*/&@/')
-              echo $ref_usable
+          for d in * ; do
+            python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
+              echo "****************************************"
+              echo ""
+              echo "****************************************" 
+              jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' ../$d-$version.json | while read -r reference ; do
+                ref_unquoted=$(echo $reference | sed 's/\"//g')
+                ref_usable=$(echo $ref_unquoted | sed 's/.*@.*/&@/')
+                echo $ref_usable
+              done
             done
           done
           

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Upload only packages built
         run: |
+          cd recipes
           python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
             echo "****************************************"
             echo ""

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -24,7 +24,15 @@ jobs:
     container:
       image: conanio/gcc10:1.43.3  # TODO: Use new docker images (gcc10)
     steps:
-      - uses: rodrigorodriguescosta/checkout@1d64c0a4a695ff5edb95596c11b430050668c83f  # FIXME: Not using actions/checkout just because of 'https://github.com/actions/checkout/pull/388'
+
+      - name: Install jq
+        working-directory: /home/conan
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq -y
+
+      - name: Check out repository code
+        uses: rodrigorodriguescosta/checkout@1d64c0a4a695ff5edb95596c11b430050668c83f  # FIXME: Not using actions/checkout just because of 'https://github.com/actions/checkout/pull/388'
         with:
           path: /home/conan/conan-recipes
 

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -68,8 +68,8 @@ jobs:
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "conan test \"$d/$folder/test_package/conanfile.py\" $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "****************************************"
-                conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=$d.json
-                cat $d.json
+                conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=$d-$version.json
+                cat $d-$version.json
                 echo conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
                 echo conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default
               done
@@ -77,6 +77,19 @@ jobs:
             cd ..
           done
 
+      - name: Upload only packages built
+        run: |
+          python ../.github/scripts/parse_config_yml.py $d/config.yml | while read -r folder version ; do 
+            echo "****************************************"
+            echo ""
+            echo "****************************************" 
+            jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' $d-$version.json | while read -r reference ; do
+              ref_unquoted=$(echo $reference | sed 's/\"//g')
+              ref_usable=$(echo $ref_unquoted | sed 's/.*@.*/&@/')
+              echo $ref_usable
+            done
+          done
+          
       #- name: Upload to remote
       #  # Upload only the packages that were built (they should be only ones in _host_ context)
       #  if: github.ref == 'refs/heads/master'

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -69,8 +69,8 @@ jobs:
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "conan test \"$d/$folder/test_package/conanfile.py\" $d/$version@jgsogo/stable --build=missing --profile:host=$profile --profile:build=default"
                 echo "****************************************"
-                conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=$d-$version.json
-                cat $d-$version.json
+                conan info $d/$version@jgsogo/stable --profile:host=../$profile --profile:build=default --json=../$d-$version.json
+                cat ../$d-$version.json
                 echo "conan install $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
                 echo "conan test "$d/$folder/test_package/conanfile.py" $d/$version@jgsogo/stable --build=missing --profile:host=../$profile --profile:build=default"
               done
@@ -85,7 +85,7 @@ jobs:
             echo "****************************************"
             echo ""
             echo "****************************************" 
-            jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' $d-$version.json | while read -r reference ; do
+            jq '.[] | select( .context=="host") | select( .binary=="Missing") | .reference' ../$d-$version.json | while read -r reference ; do
               ref_unquoted=$(echo $reference | sed 's/\"//g')
               ref_usable=$(echo $ref_unquoted | sed 's/.*@.*/&@/')
               echo $ref_usable


### PR DESCRIPTION
Due to Artifactory Free Tier limits, better if we just upload the packages we need to upload... which should never be packages from the _build_ context.